### PR TITLE
breaking change to the #perform method

### DIFF
--- a/.semver
+++ b/.semver
@@ -2,5 +2,5 @@
 :major: 2
 :minor: 0
 :patch: 0
-:special: 'alpha.1.0.0'
+:special: 'alpha.2.0.0'
 :metadata: ''

--- a/activeinteractor.gemspec
+++ b/activeinteractor.gemspec
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-GEM_VERSION = '2.0.0.alpha.1.0.0'
-SEMVER = '2.0.0-alpha.1.0.0'
+GEM_VERSION = '2.0.0.alpha.2.0.0'
+SEMVER = '2.0.0-alpha.2.0.0'
 REPO = 'https://github.com/activeinteractor/activeinteractor'
 
 Gem::Specification.new do |spec|


### PR DESCRIPTION
## Description

<!-- Summarize the pull request -->
brings the perform class methods and the perform instance methods mor…e inline with one and other

## Information

- [ ] Contains Documentation
- [ ] Contains Tests
- [ ] Contains [Signatures](https://github.com/ruby/rbs#guides)
- [x] Contains Breaking Changes

## Related Issues

<!-- besure to use the github action format for issues -->
<!-- <action> [issue_id] -->
<!-- i.e. "resloves #1" -->
<!-- delete this if there are no related issues -->
- ...

## Changelog

<!-- provide any changelog items this pull request implements -->
<!-- follow the keep a changelog format -->
<!-- see https://keepachangelog.com/en/1.0.0/ -->
<!-- delete any unused headings -->

### Added

- `ActiveInteractor::Base.perform!`
- `ActiveInteractor::Base#perform!`
- `ActiveInteractor::Base#interact`

### Changed

- `ActiveInteractor::Base#perform` is no longer an override method use `#interact` instead
