### PR TITLE
Adds support for ActiveSupport::Notifications

### DIFF
--- a/.semver
+++ b/.semver
@@ -2,5 +2,5 @@
 :major: 2
 :minor: 0
 :patch: 0
-:special: 'alpha.2.0.0'
+:special: 'alpha.2.1.0'
 :metadata: ''

--- a/activeinteractor.gemspec
+++ b/activeinteractor.gemspec
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-GEM_VERSION = '2.0.0.alpha.2.0.0'
-SEMVER = '2.0.0-alpha.2.0.0'
+GEM_VERSION = '2.0.0.alpha.2.1.0'
+SEMVER = '2.0.0-alpha.2.1.0'
 REPO = 'https://github.com/activeinteractor/activeinteractor'
 
 Gem::Specification.new do |spec|

--- a/lib/active_interactor.rb
+++ b/lib/active_interactor.rb
@@ -2,6 +2,7 @@
 
 require 'active_model'
 require 'active_support'
+require 'active_support/core_ext'
 
 require_relative 'active_interactor/errors'
 


### PR DESCRIPTION
## Description

<!-- Summarize the pull request -->
Interactors will now broadcast two events that can be subscribed to via ActiveSupport::Notifications. The two events are:

- `<interactor_class_name>::Perform`
- `<interactor_class_name>::Rollback`

## Information

- [ ] Contains Documentation
- [ ] Contains Tests
- [ ] Contains [Signatures](https://github.com/ruby/rbs#guides)
- [ ] Contains Breaking Changes

## Changelog

<!-- provide any changelog items this pull request implements -->
<!-- follow the keep a changelog format -->
<!-- see https://keepachangelog.com/en/1.0.0/ -->
<!-- delete any unused headings -->

### Changed

- `ActiveInteractor::Base#perform` to broadcast the `Perform` event
- `ActiveInteractor::Base#rollback` to broadcast the `Rollback` event

### Fixed

- errors caused by not requiring `active_support/core_ext`
