### PR TITLE
Introduces context classes

### DIFF
--- a/.semver
+++ b/.semver
@@ -2,5 +2,5 @@
 :major: 2
 :minor: 0
 :patch: 0
-:special: 'alpha.2.1.0'
+:special: 'alpha.2.2.0'
 :metadata: ''

--- a/activeinteractor.gemspec
+++ b/activeinteractor.gemspec
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-GEM_VERSION = '2.0.0.alpha.2.1.0'
-SEMVER = '2.0.0-alpha.2.1.0'
+GEM_VERSION = '2.0.0.alpha.2.2.0'
+SEMVER = '2.0.0-alpha.2.2.0'
 REPO = 'https://github.com/activeinteractor/activeinteractor'
 
 Gem::Specification.new do |spec|

--- a/lib/active_interactor.rb
+++ b/lib/active_interactor.rb
@@ -10,5 +10,7 @@ module ActiveInteractor
   extend ActiveSupport::Autoload
 
   autoload :Base
+  autoload :Context
+  autoload :HasActiveModelErrors
   autoload :Result
 end

--- a/lib/active_interactor/context.rb
+++ b/lib/active_interactor/context.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module ActiveInteractor
+  module Context
+    extend ActiveSupport::Autoload
+
+    autoload :Attribute
+    autoload :AttributeRegistration
+    autoload :AttributeSet
+    autoload :AttributeAssignment
+    autoload :Base
+    autoload :Input
+    autoload :Output
+    autoload :Runtime
+  end
+end

--- a/lib/active_interactor/context/attribute.rb
+++ b/lib/active_interactor/context/attribute.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module ActiveInteractor
+  module Context
+    class Attribute
+      NO_DEFAULT_VALUE = :__no_default_value__
+      attr_reader :description, :error_messages, :name
+
+      def initialize(owner, name, type, description = nil, **options)
+        @owner = owner
+        @name = name.to_sym
+        @type_expression = type
+        @description = description || options[:description]
+        @options = { required: false, default: NO_DEFAULT_VALUE }.merge(options)
+        @error_messages = []
+      end
+
+      def assign_value(value)
+        @user_provided_value = value
+      end
+
+      def default_value
+        return if @options[:default] == NO_DEFAULT_VALUE
+
+        @options[:default]
+      end
+
+      def required?
+        @options[:required]
+      end
+
+      def type
+        @type_expression
+      end
+
+      def validate!
+        return true unless required? && value.nil?
+
+        error_messages << :blank
+      end
+
+      def value
+        @user_provided_value || default_value
+      end
+    end
+  end
+end

--- a/lib/active_interactor/context/attribute_assignment.rb
+++ b/lib/active_interactor/context/attribute_assignment.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module ActiveInteractor
+  module Context
+    module AttributeAssignment
+      extend ActiveSupport::Concern
+
+      def [](attribute_name)
+        read_attribute_value(attribute_name)
+      end
+
+      def []=(attribute_name, value)
+        assign_attribute_value(attribute_name, value)
+      end
+
+      protected
+
+      def assign_attribute_value(attribute_name, value)
+        attribute = attribute_set.find(attribute_name)
+        raise NoMethodError, "unknown attribute '#{attribute_name}' for #{self.class.name}" unless attribute
+
+        attribute.assign_value(value)
+      end
+
+      def assignment_method_missing(method_name, *arguments)
+        if arguments.length != 1
+          raise ArgumentError,
+                "wrong number of arguments (given #{arguments.length}, expected 1)"
+        end
+
+        assign_attribute_value(method_name, arguments.first)
+      end
+
+      def method_missing(method_id, *arguments)
+        return super unless respond_to_missing?(method_id)
+
+        method_name = method_id[/.*(?==\z)/m]
+        return assignment_method_missing(method_name, *arguments) if method_name
+
+        read_attribute_value(method_id)
+      end
+
+      def read_attribute_value(attribute_name)
+        attribute = attribute_set.find(attribute_name)
+        raise NoMethodError, "unknown attribute '#{attribute_name}' for #{self.class.name}" unless attribute
+
+        attribute.value
+      end
+
+      def respond_to_missing?(method_name, _include_private = false)
+        return true if attribute_set.attribute_names.include?(method_name.to_sym)
+        return true if attribute_set.attribute_names.include?(method_name[/.*(?==\z)/m]&.to_sym)
+
+        super
+      end
+    end
+  end
+end

--- a/lib/active_interactor/context/attribute_registration.rb
+++ b/lib/active_interactor/context/attribute_registration.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module ActiveInteractor
+  module Context
+    module AttributeRegistration
+      extend ActiveSupport::Concern
+
+      module ClassMethods
+        protected
+
+        def attribute_set
+          @attribute_set ||= AttributeSet.new(self)
+        end
+      end
+
+      included do
+        extend ClassMethods
+      end
+
+      protected
+
+      def attribute_set
+        @attribute_set ||= AttributeSet.new(self, *self.class.send(:attribute_set).attributes.map(&:dup))
+      end
+    end
+  end
+end

--- a/lib/active_interactor/context/attribute_set.rb
+++ b/lib/active_interactor/context/attribute_set.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module ActiveInteractor
+  module Context
+    class AttributeSet
+      def initialize(owner, *attributes)
+        @owner = owner
+        @set = {}
+        attributes.each { |attribute| @set[attribute.name] = attribute }
+      end
+
+      def add(*attribute_args)
+        attribute_options = attribute_args.extract_options!
+        attribute = Attribute.new(@owner, *attribute_args, **attribute_options)
+        @set[attribute.name] = attribute
+      end
+
+      def attribute_names
+        @set.keys
+      end
+
+      def attributes
+        @set.values
+      end
+
+      def find(attribute_name)
+        @set[attribute_name.to_sym]
+      end
+
+      def merge(attributes)
+        attributes.each { |attribute| @set[attribute.name] = attribute }
+      end
+    end
+  end
+end

--- a/lib/active_interactor/context/base.rb
+++ b/lib/active_interactor/context/base.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module ActiveInteractor
+  module Context
+    class Base
+      include ActiveModel::Validations
+      include HasActiveModelErrors
+      include AttributeRegistration
+      include AttributeAssignment
+
+      attr_reader :errors
+
+      def initialize(attributes = {})
+        @errors = ActiveModel::Errors.new(self)
+        attribute_set.attributes.each do |attribute|
+          next unless attributes.with_indifferent_access.key?(attribute.name)
+
+          assign_attribute_value(attribute.name, attributes.with_indifferent_access[attribute.name])
+        end
+      end
+
+      def validate!
+        attribute_set.attributes.each do |attribute|
+          attribute.validate!
+          attribute.error_messages.each { |message| errors.add(attribute.name, message) }
+        end
+      end
+    end
+  end
+end

--- a/lib/active_interactor/context/input.rb
+++ b/lib/active_interactor/context/input.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module ActiveInteractor
+  module Context
+    class Input < Base
+      def self.argument(*attribute_args)
+        attribute_set.add(*attribute_args)
+      end
+
+      def self.argument_names
+        attribute_set.attribute_names
+      end
+
+      def self.arguments
+        attribute_set.attributes
+      end
+    end
+  end
+end

--- a/lib/active_interactor/context/output.rb
+++ b/lib/active_interactor/context/output.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module ActiveInteractor
+  module Context
+    class Output < Base
+      delegate :to_h, :to_hash, :to_json, to: :fields
+
+      def self.returns(*attribute_args)
+        attribute_set.add(*attribute_args)
+      end
+
+      def self.field_names
+        attribute_set.attribute_names
+      end
+
+      def self.fields
+        attribute_set.attributes
+      end
+
+      def fields
+        attribute_set.attributes.each_with_object({}) do |attribute, result|
+          result[attribute.name] = attribute.value
+        end
+      end
+    end
+  end
+end

--- a/lib/active_interactor/context/runtime.rb
+++ b/lib/active_interactor/context/runtime.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module ActiveInteractor
+  module Context
+    class Runtime < Base
+      def initialize(attributes = {})
+        super
+        @table = {}
+      end
+
+      def attributes
+        clean = attribute_set.attributes.each_with_object({}) do |attribute, result|
+          result[attribute.name] = attribute.value
+        end
+        @table.merge(clean)
+      end
+
+      private
+
+      def assign_attribute_value(attribute_name, value)
+        attribute = attribute_set.find(attribute_name)
+        return super if attribute
+
+        assign_dirty_attribute_value(attribute_name, value)
+      end
+
+      def assign_dirty_attribute_value(attribute_name, value)
+        @table[attribute_name.to_sym] = value
+      end
+
+      def method_missing(method_id, *arguments)
+        method_name = method_id[/.*(?==\z)/m]
+        return assignment_method_missing(method_name, *arguments) if method_name
+
+        read_attribute_value(method_id)
+      end
+
+      def read_attribute_value(attribute_name)
+        attribute = attribute_set.find(attribute_name)
+        return super if attribute
+
+        read_dirty_attribute_value(attribute_name)
+      end
+
+      def read_dirty_attribute_value(attribute_name)
+        @table[attribute_name.to_sym]
+      end
+
+      def respond_to_missing?(_method_name, _include_private = false)
+        true
+      end
+    end
+  end
+end

--- a/lib/active_interactor/has_active_model_errors.rb
+++ b/lib/active_interactor/has_active_model_errors.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module ActiveInteractor
+  module HasActiveModelErrors
+    extend ActiveSupport::Concern
+
+    module ClassMethods
+      def self.human_attribute_name(attribute, _options = {})
+        attribute.respond_to?(:to_s) ? attribute.to_s.humanize : attribute
+      end
+
+      def self.lookup_ancestors
+        [self]
+      end
+    end
+
+    included do
+      extend ActiveModel::Naming
+      extend ClassMethods
+
+      attr_reader :errors
+    end
+
+    def read_attribute_for_validation(attribute_name)
+      send(attribute_name.to_sym)
+    end
+  end
+end


### PR DESCRIPTION
## Description

<!-- Summarize the pull request -->
Make context a little friendlier to interact with by introducing class objects instead of using hashes.

## Information

- [ ] Contains Documentation
- [ ] Contains Tests
- [ ] Contains [Signatures](https://github.com/ruby/rbs#guides)
- [ ] Contains Breaking Changes

## Changelog

<!-- provide any changelog items this pull request implements -->
<!-- follow the keep a changelog format -->
<!-- see https://keepachangelog.com/en/1.0.0/ -->
<!-- delete any unused headings -->

### Added

- `ActiveInteractor::Context`
- `ActiveInteractor::Context::Attribute`
- `ActiveInteractor::Context::AttributeAssignment`
- `ActiveInteractor::Context::AttributeRegistration`
- `ActiveInteractor::Context::AttributeSet`
- `ActiveInteractor::Context::Base`
- `ActiveInteractor::Context::Input`
- `ActiveInteractor::Context::Output`
- `ActiveInteractor::Context::Runtime`
- `ActiveInteractor::HasActiveModelErrors`
- `ActiveInteractor::Base.accepts_arguments_matching`
- `ActiveInteractor::Base.argument_names`
- `ActiveInteractor::Base.arguments`
- `ActiveInteractor::Base.field_names`
- `ActiveInteractor::Base.fields`
- `ActiveInteractor::Base.input_context`
- `ActiveInteractor::Base.input_context_class`
- `ActiveInteractor::Base.output_context`
- `ActiveInteractor::Base.output_context_class`
- `ActiveInteractor::Base.returns_data_matching`
- `ActiveInteractor::Base.runtime_context_class`
- `ActiveInteractor::Result#to_json`
- `ActiveInteractor::Result#to_h`
- `ActiveInteractor::Result#to_hash`

### Changed

- `ActiveInteractor::Base` now uses `ActiveInteractor::Context` classes instead of raw hashes
