### PR TITLE
introduces type contract validation

### DIFF
--- a/.semver
+++ b/.semver
@@ -2,5 +2,5 @@
 :major: 2
 :minor: 0
 :patch: 0
-:special: 'alpha.2.2.0'
+:special: 'alpha.2.3.0'
 :metadata: ''

--- a/activeinteractor.gemspec
+++ b/activeinteractor.gemspec
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-GEM_VERSION = '2.0.0.alpha.2.2.0'
-SEMVER = '2.0.0-alpha.2.2.0'
+GEM_VERSION = '2.0.0.alpha.2.3.0'
+SEMVER = '2.0.0-alpha.2.3.0'
 REPO = 'https://github.com/activeinteractor/activeinteractor'
 
 Gem::Specification.new do |spec|

--- a/lib/active_interactor.rb
+++ b/lib/active_interactor.rb
@@ -13,4 +13,5 @@ module ActiveInteractor
   autoload :Context
   autoload :HasActiveModelErrors
   autoload :Result
+  autoload :Type
 end

--- a/lib/active_interactor/base.rb
+++ b/lib/active_interactor/base.rb
@@ -2,6 +2,8 @@
 
 module ActiveInteractor
   class Base
+    include Type::HasTypes
+
     class << self
       delegate :argument, :argument_names, :arguments, to: :input_context_class
       delegate :returns, :field_names, :fields, to: :output_context_class

--- a/lib/active_interactor/context/attribute.rb
+++ b/lib/active_interactor/context/attribute.rb
@@ -34,13 +34,38 @@ module ActiveInteractor
       end
 
       def validate!
+        validate_presence! && validate_type!
+      end
+
+      def value
+        @user_provided_value || default_value
+      end
+
+      private
+
+      def type_is_a_active_interactor_type?
+        type.is_a?(ActiveInteractor::Type::Base) || type.superclass == ActiveInteractor::Type::Base
+      end
+
+      def validate_presence!
         return true unless required? && value.nil?
 
         error_messages << :blank
       end
 
-      def value
-        @user_provided_value || default_value
+      def validate_type!
+        return true if value.nil?
+        return true if %i[any untyped].include?(type)
+
+        if type_is_a_active_interactor_type?
+          return true if type.valid?(value)
+
+          error_messages << :invalid
+        elsif value.is_a?(type)
+          return true
+        end
+
+        error_messages << :invalid
       end
     end
   end

--- a/lib/active_interactor/context/base.rb
+++ b/lib/active_interactor/context/base.rb
@@ -7,6 +7,7 @@ module ActiveInteractor
       include HasActiveModelErrors
       include AttributeRegistration
       include AttributeAssignment
+      include Type::HasTypes
 
       attr_reader :errors
 

--- a/lib/active_interactor/type.rb
+++ b/lib/active_interactor/type.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module ActiveInteractor
+  module Type
+    extend ActiveSupport::Autoload
+
+    autoload :Base
+    autoload :Boolean
+    autoload :HasTypes
+    autoload :List
+    autoload :Union
+  end
+end

--- a/lib/active_interactor/type/base.rb
+++ b/lib/active_interactor/type/base.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module ActiveInteractor
+  module Type
+    class Base
+      def self.valid?(value); end
+    end
+  end
+end

--- a/lib/active_interactor/type/boolean.rb
+++ b/lib/active_interactor/type/boolean.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module ActiveInteractor
+  module Type
+    class Boolean < Base
+      TRUE_VALUES = [true, 1, '1', 't', 'T', 'true', 'TRUE', 'on', 'ON', 'yes', 'YES'].freeze
+      FALSE_VALUES = [false, 0, '0', 'f', 'F', 'false', 'FALSE', 'off', 'OFF', 'no', 'NO'].freeze
+
+      def self.valid?(value)
+        (TRUE_VALUES + FALSE_VALUES).include?(value)
+      end
+    end
+  end
+end

--- a/lib/active_interactor/type/has_types.rb
+++ b/lib/active_interactor/type/has_types.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module ActiveInteractor
+  module Type
+    module HasTypes
+      extend ActiveSupport::Concern
+
+      Boolean = ActiveInteractor::Type::Boolean
+
+      module ClassMethods
+        def any
+          :any
+        end
+
+        def list(type)
+          List.new(type)
+        end
+        alias array list
+
+        def union(*types)
+          Union.new(*types)
+        end
+
+        def untyped
+          :untyped
+        end
+      end
+
+      included do
+        extend ClassMethods
+      end
+    end
+  end
+end

--- a/lib/active_interactor/type/list.rb
+++ b/lib/active_interactor/type/list.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module ActiveInteractor
+  module Type
+    class List < Base
+      def initialize(type) # rubocop:disable Lint/MissingSuper
+        @type = type
+      end
+
+      def valid?(value)
+        return false unless value.is_a?(Array)
+
+        value.all? do |element|
+          element.nil? || element.is_a?(@type) || (@type.is_a?(ActiveInteractor::Type::Base) && @type.valid?(element))
+        end
+      end
+
+      private
+
+      def value_is_a_valid_active_interactor_type?(_type, value)
+        unless @type.is_a?(ActiveInteractor::Type::Base) || @type.superclass == ActiveInteractor::Type::Base
+          return false
+        end
+
+        @type.valid?(value)
+      end
+    end
+  end
+end

--- a/lib/active_interactor/type/union.rb
+++ b/lib/active_interactor/type/union.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module ActiveInteractor
+  module Type
+    class Union < Base
+      def initialize(*types) # rubocop:disable Lint/MissingSuper
+        @valid_types = types
+      end
+
+      def valid?(value)
+        return true if value.nil?
+
+        @valid_types.any? do |type|
+          value_is_a_valid_active_interactor_type?(type, value) || value.is_a?(type)
+        end
+      end
+
+      private
+
+      def value_is_a_valid_active_interactor_type?(type, value)
+        return false unless type.is_a?(ActiveInteractor::Type::Base) || type.superclass == ActiveInteractor::Type::Base
+
+        type.valid?(value)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description

<!-- Summarize the pull request -->
Interactors will now fail if the types defined for `argument` or `returns` are not satisfied.

## Information

- [ ] Contains Documentation
- [ ] Contains Tests
- [ ] Contains [Signatures](https://github.com/ruby/rbs#guides)
- [ ] Contains Breaking Changes

## Changelog

<!-- provide any changelog items this pull request implements -->
<!-- follow the keep a changelog format -->
<!-- see https://keepachangelog.com/en/1.0.0/ -->
<!-- delete any unused headings -->

### Added

- `ActiveInteractor::Type`
- `ActiveInteractor::Type::Base`
- `ActiveInteractor::Type::Boolean`
- `ActiveInteractor::Type::HasTypes`
- `ActiveInteractor::Type::List`
- `ActiveInteractor::Type::Union`

### Changed

- `ActiveInteractor::Context::Attribute#validate!` will now check that the value is of the type defined by the context
