### PR TITLE
fixes a bug with `ActiveInteractor::HasActiveModelErrors`

### DIFF
--- a/.semver
+++ b/.semver
@@ -2,5 +2,5 @@
 :major: 2
 :minor: 0
 :patch: 0
-:special: 'alpha.2.3.0'
+:special: 'alpha.2.3.1'
 :metadata: ''

--- a/activeinteractor.gemspec
+++ b/activeinteractor.gemspec
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-GEM_VERSION = '2.0.0.alpha.2.3.0'
-SEMVER = '2.0.0-alpha.2.3.0'
+GEM_VERSION = '2.0.0.alpha.2.3.1'
+SEMVER = '2.0.0-alpha.2.3.1'
 REPO = 'https://github.com/activeinteractor/activeinteractor'
 
 Gem::Specification.new do |spec|

--- a/lib/active_interactor/context/attribute_assignment.rb
+++ b/lib/active_interactor/context/attribute_assignment.rb
@@ -5,6 +5,14 @@ module ActiveInteractor
     module AttributeAssignment
       extend ActiveSupport::Concern
 
+      def initialize(attributes = {})
+        attribute_set.attributes.each do |attribute|
+          next unless attributes.with_indifferent_access.key?(attribute.name)
+
+          assign_attribute_value(attribute.name, attributes.with_indifferent_access[attribute.name])
+        end
+      end
+
       def [](attribute_name)
         read_attribute_value(attribute_name)
       end

--- a/lib/active_interactor/context/base.rb
+++ b/lib/active_interactor/context/base.rb
@@ -9,15 +9,9 @@ module ActiveInteractor
       include AttributeAssignment
       include Type::HasTypes
 
-      attr_reader :errors
-
       def initialize(attributes = {})
+        super
         @errors = ActiveModel::Errors.new(self)
-        attribute_set.attributes.each do |attribute|
-          next unless attributes.with_indifferent_access.key?(attribute.name)
-
-          assign_attribute_value(attribute.name, attributes.with_indifferent_access[attribute.name])
-        end
       end
 
       def validate!

--- a/lib/active_interactor/has_active_model_errors.rb
+++ b/lib/active_interactor/has_active_model_errors.rb
@@ -4,12 +4,14 @@ module ActiveInteractor
   module HasActiveModelErrors
     extend ActiveSupport::Concern
 
+    attr_reader :errors
+
     module ClassMethods
-      def self.human_attribute_name(attribute, _options = {})
+      def human_attribute_name(attribute, _options = {})
         attribute.respond_to?(:to_s) ? attribute.to_s.humanize : attribute
       end
 
-      def self.lookup_ancestors
+      def lookup_ancestors
         [self]
       end
     end
@@ -17,8 +19,6 @@ module ActiveInteractor
     included do
       extend ActiveModel::Naming
       extend ClassMethods
-
-      attr_reader :errors
     end
 
     def read_attribute_for_validation(attribute_name)

--- a/lib/active_interactor/result.rb
+++ b/lib/active_interactor/result.rb
@@ -13,7 +13,7 @@ module ActiveInteractor
       failed_at_output: 3
     }.freeze
 
-    attr_reader :data, :errors
+    attr_reader :data
 
     class << self
       def success(data: {})


### PR DESCRIPTION
## Description

<!-- Summarize the pull request -->
Fixes `NoMethodErrors` for `ActiveModel::Errors` in `ActiveInteractor::Context::Base` and `ActiveInteractor::Result`

## Information

- [ ] Contains Documentation
- [ ] Contains Tests
- [ ] Contains [Signatures](https://github.com/ruby/rbs#guides)
- [ ] Contains Breaking Changes

## Changelog

<!-- provide any changelog items this pull request implements -->
<!-- follow the keep a changelog format -->
<!-- see https://keepachangelog.com/en/1.0.0/ -->
<!-- delete any unused headings -->

### Fixed

- `NoMethodError` `human_attribute_name` for `ActiveInteractor::Context::Base` and `ActiveInteractor::Result`
- `NoMethodError` `lookup_ancestors` for `ActiveInteractor::Context::Base` and `ActiveInteractor::Result`
