### PR TITLE
return a result context

### DIFF
--- a/.semver
+++ b/.semver
@@ -2,5 +2,5 @@
 :major: 2
 :minor: 0
 :patch: 0
-:special: 'alpha.2.3.2'
+:special: 'alpha.2.3.3'
 :metadata: ''

--- a/activeinteractor.gemspec
+++ b/activeinteractor.gemspec
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-GEM_VERSION = '2.0.0.alpha.2.3.2'
-SEMVER = '2.0.0-alpha.2.3.2'
+GEM_VERSION = '2.0.0.alpha.2.3.3'
+SEMVER = '2.0.0-alpha.2.3.3'
 REPO = 'https://github.com/activeinteractor/activeinteractor'
 
 Gem::Specification.new do |spec|

--- a/lib/active_interactor/base.rb
+++ b/lib/active_interactor/base.rb
@@ -57,7 +57,7 @@ module ActiveInteractor
       with_notification(:perform) do |payload|
         interact
         generate_and_validate_output_context!
-        payload[:result] = Result.success(data: @output)
+        payload[:result] = Result.success(data: output_to_result_context!)
       end
     end
 
@@ -90,9 +90,13 @@ module ActiveInteractor
     def generate_and_validate_output_context!
       @output = self.class.output_context_class.new(context.attributes)
       @output.validate!
-      return @output if @output.errors.empty?
+      return if @output.errors.empty?
 
       raise Error, Result.failure(errors: @output.errors, status: Result::STATUS[:failed_at_output])
+    end
+
+    def output_to_result_context!
+      Context::Result.for_output_context(self.class, @output)
     end
 
     def validate_input_and_generate_runtime_context!

--- a/lib/active_interactor/context.rb
+++ b/lib/active_interactor/context.rb
@@ -11,6 +11,7 @@ module ActiveInteractor
     autoload :Base
     autoload :Input
     autoload :Output
+    autoload :Result
     autoload :Runtime
   end
 end

--- a/lib/active_interactor/context/result.rb
+++ b/lib/active_interactor/context/result.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module ActiveInteractor
+  module Context
+    class Result
+      def self.for_output_context(owner, context)
+        owner.const_set(:ResultContext, Class.new(self))
+        context.fields.each_key { |field| owner::ResultContext.send(:attr_reader, field) }
+        owner::ResultContext.new(context.fields)
+      end
+
+      def initialize(attributes = {})
+        attributes.each_pair { |key, value| instance_variable_set(:"@#{key}", value) }
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description

<!-- Summarize the pull request -->
Previously an `ActiveInteractor::Result` would return a collection of `ActiveInteractor::Context::Attribute` objects in for `ActiveInteractor::Result#data`.  This patch changes `ActiveInteractor::Result#data` to be an `ActiveInteractor::Context::Result` object with the appropriate keys and values.

## Information

- [ ] Contains Documentation
- [ ] Contains Tests
- [ ] Contains [Signatures](https://github.com/ruby/rbs#guides)
- [ ] Contains Breaking Changes

## Changelog

<!-- provide any changelog items this pull request implements -->
<!-- follow the keep a changelog format -->
<!-- see https://keepachangelog.com/en/1.0.0/ -->
<!-- delete any unused headings -->

### Added

- `ActiveInteractor::Context::Result`

### Changed

- `ActiveInteractor::Result#data` to return an `ActiveInteractor::Context::Result`
