### PR TITLE
Fixes an error on #fail!

### DIFF
--- a/.semver
+++ b/.semver
@@ -2,5 +2,5 @@
 :major: 2
 :minor: 0
 :patch: 0
-:special: 'alpha.2.3.4'
+:special: 'alpha.2.3.5'
 :metadata: ''

--- a/activeinteractor.gemspec
+++ b/activeinteractor.gemspec
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-GEM_VERSION = '2.0.0.alpha.2.3.4'
-SEMVER = '2.0.0-alpha.2.3.4'
+GEM_VERSION = '2.0.0.alpha.2.3.5'
+SEMVER = '2.0.0-alpha.2.3.5'
 HOME_URL = 'https://activeinteractor.org'
 REPO_URL = 'https://github.com/activeinteractor/activeinteractor'
 

--- a/lib/active_interactor/interactor/base.rb
+++ b/lib/active_interactor/interactor/base.rb
@@ -26,7 +26,7 @@ module ActiveInteractor
         result = nil
         with_notification(:rollback) do |payload|
           rollback
-          result = Result.failure(data: parse_output!, errors: errors)
+          result = Result.failure(data: @output, errors: errors)
           payload[:result] = result
         end
 


### PR DESCRIPTION
## Description

<!-- Summarize the pull request -->
Fixes an error for `ActiveInteractor::Interactor::Base#fail!` that called a missing method `#parse_output!`

## Information

- [ ] Contains Documentation
- [ ] Contains Tests
- [ ] Contains [Signatures](https://github.com/ruby/rbs#guides)
- [ ] Contains Breaking Changes

## Related Issues

<!-- besure to use the github action format for issues -->
<!-- <action> [issue_id] -->
<!-- i.e. "resloves #1" -->
<!-- delete this if there are no related issues -->
- resolves #27 

## Changelog

<!-- provide any changelog items this pull request implements -->
<!-- follow the keep a changelog format -->
<!-- see https://keepachangelog.com/en/1.0.0/ -->
<!-- delete any unused headings -->

### Fixed

- #27 Generic undefined method parse_output! for ActiveInteractor::Interactor::Base
