### PR TITLE
add Hash methods to `ActiveInteractor::Context::Result`

### DIFF
--- a/lib/active_interactor/context/result.rb
+++ b/lib/active_interactor/context/result.rb
@@ -3,6 +3,8 @@
 module ActiveInteractor
   module Context
     class Result
+      delegate :[], :as_json, :to_json, to: :to_hash
+
       def self.register_owner(owner)
         owner.const_set(:ResultContext, Class.new(self))
       end
@@ -13,8 +15,17 @@ module ActiveInteractor
       end
 
       def initialize(attributes = {})
-        attributes.each_pair { |key, value| instance_variable_set(:"@#{key}", value) }
+        @attributes = {}
+        attributes.each_pair do |key, value|
+          instance_variable_set(:"@#{key}", value)
+          @attributes[key] = value
+        end
       end
+
+      def to_hash
+        @attributes.with_indifferent_access
+      end
+      alias to_h to_hash
     end
   end
 end

--- a/lib/active_interactor/result.rb
+++ b/lib/active_interactor/result.rb
@@ -127,7 +127,7 @@ module ActiveInteractor
 
     # @private
     def read_attribute_for_validation(attribute_name)
-      data.send(attribute_name.to_sym)
+      data&.send(attribute_name.to_sym)
     end
 
     # Whether or not the {ActiveInteractor::Interactor::Base result} is a success

--- a/test.rb
+++ b/test.rb
@@ -26,7 +26,7 @@ class CreateUser < ActiveInteractor::Base
 
   def interact
     context.user = User.new
-    return unless context.password == context.password_confirmation
+    fail!(password: %i[invalid]) unless context.password == context.password_confirmation
 
     set_user_attributes
   end
@@ -46,6 +46,7 @@ end
 success_result = CreateUser.perform(login: 'testuser', password: 'password', password_confirmation: 'password')
 puts success_result.success?
 puts success_result.to_json
+puts success_result.data[:user]
 
 failure_result = CreateUser.perform(login: 'testuser', password: 'password', password_confirmation: 'notpassword')
 puts failure_result.success?


### PR DESCRIPTION


## Description

<!-- Summarize the pull request -->
Adds Hash methods to the `ActiveInteractor::Context::Result` class.  Additionally fixes a bug when `ActiveInteractor::Result#data` is `nil` that would raise a `NoMethodError` for `read_attribute_for_validation`.

## Information

- [ ] Contains Documentation
- [x] Contains Tests
- [ ] Contains [Signatures](https://github.com/ruby/rbs#guides)
- [ ] Contains Breaking Changes

## Changelog

<!-- provide any changelog items this pull request implements -->
<!-- follow the keep a changelog format -->
<!-- see https://keepachangelog.com/en/1.0.0/ -->
<!-- delete any unused headings -->

### Added

- `ActiveInteractor::Context::Result#[]`
- `ActiveInteractor::Context::Result#as_json`
- `ActiveInteractor::Context::Result#to_json`
- `ActiveInteractor::Context::Result#to_h`
- `ActiveInteractor::Context::Result#to_hash`

### Fixed

- `ActiveInteractor::Result#data` will no longer throw a `NoMethodError` for `read_attribute_for_validation` when `ActiveInteractor::Result#data` is `nil`
